### PR TITLE
Update Chart.js

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -250,6 +250,7 @@ export default class Chart extends React.Component {
       label: this.dataTable.getColumnLabel(columnIndex),
       type: this.dataTable.getColumnType(columnIndex),
       sourceColumn: columnIndex,
+      role: this.dataTable.getColumnRole(columnIndex) // addedBy minam.cho(devbada) cause of 'All series on a given axis must be of the same data type': July 10, 2017
     };
   }
 
@@ -259,6 +260,7 @@ export default class Chart extends React.Component {
       label: this.dataTable.getColumnLabel(columnIndex),
       type: this.dataTable.getColumnType(columnIndex),
       calc: () => null,
+      role: this.dataTable.getColumnRole(columnIndex) // addedBy minam.cho(devbada) cause of 'All series on a given axis must be of the same data type': July 10, 2017
     };
   }
   addEmptyColumnTo(columns, columnIndex) {


### PR DESCRIPTION
added Role. cause of it has an error when legend click when Column has Role(*annotation) property.
The error message is "All series on a given axis must be of the same data type"

Chart.js > line 252 and line 262, inside function buildColumnFromSourceData( ... ) and buildEmptyColumnFromSourceData( ...) 
* see the commend at start addedBy minam.cho - - -

```
buildColumnFromSourceData(columnIndex) {
    debug('buildColumnFromSourceData', columnIndex);
    return {
      label: this.dataTable.getColumnLabel(columnIndex),
      type: this.dataTable.getColumnType(columnIndex),
      sourceColumn: columnIndex,
      role: this.dataTable.getColumnRole(columnIndex) // addedBy minam.cho(devbada) cause of 'All series on a given axis must be of the same data type': July 10, 2017
    };
  }

  buildEmptyColumnFromSourceData(columnIndex) {
    debug('buildEmptyColumnFromSourceData', columnIndex);
    return {
      label: this.dataTable.getColumnLabel(columnIndex),
      type: this.dataTable.getColumnType(columnIndex),
      calc: () => null,
      role: this.dataTable.getColumnRole(columnIndex) // addedBy minam.cho(devbada) cause of 'All series on a given axis must be of the same data type': July 10, 2017
    };
  }
```